### PR TITLE
Switch to Alpine image to reduce container size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.20-alpine
+FROM python:3.12-alpine
 WORKDIR /usr/src/app
 COPY requirements.txt /usr/src/app/
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.9.20-alpine
 WORKDIR /usr/src/app
 COPY requirements.txt /usr/src/app/
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Image size goes from 367.24 MB down to 64MB
This change affects Dockerfile only

